### PR TITLE
Add OpenMW commits up to 19 Jan

### DIFF
--- a/components/nifbullet/bulletnifloader.cpp
+++ b/components/nifbullet/bulletnifloader.cpp
@@ -268,7 +268,9 @@ void BulletNifLoader::handleNiTriShape(const Nif::NiTriShape *shape, int flags, 
 
     if (shape->data.empty())
         return;
-    if (shape->data->triangles->empty())
+
+    const Nif::NiTriShapeData *data = shape->data.getPtr();
+    if (!data->triangles || !data->vertices)
         return;
 
     if (isAnimated)
@@ -277,8 +279,6 @@ void BulletNifLoader::handleNiTriShape(const Nif::NiTriShape *shape, int flags, 
             mCompoundShape = new btCompoundShape();
 
         btTriangleMesh* childMesh = new btTriangleMesh();
-
-        const Nif::NiTriShapeData *data = shape->data.getPtr();
 
         childMesh->preallocateVertices(data->vertices->size());
         childMesh->preallocateIndices(data->triangles->size());
@@ -320,7 +320,6 @@ void BulletNifLoader::handleNiTriShape(const Nif::NiTriShape *shape, int flags, 
             mStaticMesh = new btTriangleMesh(false);
 
         // Static shape, just transform all vertices into position
-        const Nif::NiTriShapeData *data = shape->data.getPtr();
         const osg::Vec3Array& vertices = *data->vertices;
         const osg::DrawElementsUShort& triangles = *data->triangles;
 


### PR DESCRIPTION
…Bug #3580)

The first part of the fix is to assign VBO/EBO's upon loading the array in the Nif reader. This avoids triggering the 'addVertexBufferObjectIfRequired' code path in osg::Geometry which has the race condition when two threads add the same Array at the same time. Essentially, we want the Arrays to be 'const' when they come out of the Nif reader.

The second part of the fix is to make sure not to create empty arrays in the Nif reader (importantly, not assigning a VBO to the empty array). This empty array would be deleted when the NIFFile is cleaned up, and the detachment of the VBO assigned to it (which is still in use by other arrays) would cause threading issues.

This rare crash bug was first introduced with commit a7c5beb7c5d495446e5d7facaa780fbf851d1848. When using OSG dev version 3.5 the crashes were a little more prevalent, because 'addVertexBufferObjectIfRequired' in osg::Geometry is now used even when VBO's are disabled (as part of the VAO support changes).