### PR TITLE
Add OpenMW commits up to 29 Jan

### DIFF
--- a/apps/openmw/mwscript/interpretercontext.cpp
+++ b/apps/openmw/mwscript/interpretercontext.cpp
@@ -582,7 +582,8 @@ namespace MWScript
         if (!mReference.isEmpty() && base == mReference)
         {
             mReference = updated;
-            mLocals = &mReference.getRefData().getLocals();
+            if (mLocals == &base.getRefData().getLocals())
+                mLocals = &mReference.getRefData().getLocals();
         }
     }
 }


### PR DESCRIPTION
…f's locals when interpreting a targeted global script (Fixes #3738)

The interpreter context of a targeted global script would point to the target's locals instead of the global script instance's locals when the target changed cell during script execution. Credit to scrawl for the solution.