### PR TITLE
[DO NOT MERGE][Browser] Very very very temp fix for memory leak

### DIFF
--- a/apps/browser/netutils/Utils.cpp
+++ b/apps/browser/netutils/Utils.cpp
@@ -113,19 +113,20 @@ ServerExtendedData getExtendedData(const char *addr, unsigned short port)
     if(queue == -1) // connection is failed
         return data;
 
-    {
-        RakNet::BitStream bs;
-        bs.Write((unsigned char) (ID_USER_PACKET_ENUM + 1));
-        peer->Send(&bs, HIGH_PRIORITY, RELIABLE_ORDERED, 0, RakNet::UNASSIGNED_SYSTEM_ADDRESS, true);
-    }
+    RakNet::BitStream bs;
+    bs.Write((unsigned char) (ID_USER_PACKET_ENUM + 1));
+    peer->Send(&bs, HIGH_PRIORITY, RELIABLE_ORDERED, 0, RakNet::UNASSIGNED_SYSTEM_ADDRESS, true);
 
     RakNet::Packet *packet;
     bool done = false;
-    while (!done)
+
+    // This temporary fix causes extended server data to not be displayed for any server
+    int attempts = 0;
+    while (!done && ++attempts < 5000) 
     {
         for (packet = peer->Receive(); packet; peer->DeallocatePacket(packet), packet = peer->Receive())
         {
-            if(packet->data[0] == (ID_USER_PACKET_ENUM+1))
+            if(packet->data[0] == (ID_USER_PACKET_ENUM + 1))
             {
                 RakNet::BitStream bs(packet->data, packet->length, false);
                 bs.IgnoreBytes(1);


### PR DESCRIPTION
This does not solve the bigger issue here, only alleviates a temporary problem.

The bug: a memory leak occurs when connecting to Norc's server if there is more than 1 player online. Norc's server happens to be the only ARM-built server online. Requires some more looking into.