### PR TITLE
[General] Temporarily disable the new OpenMW crash catcher

### DIFF
--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -210,12 +210,6 @@ add_component_dir (fallback
     fallback validate
     )
 
-if(NOT WIN32 AND NOT ANDROID)
-    add_component_dir (crashcatcher
-        crashcatcher
-    )
-endif()
-
 set (ESM_UI ${CMAKE_SOURCE_DIR}/files/ui/contentselector.ui
     )
 

--- a/components/crashcatcher/crashcatcher.hpp
+++ b/components/crashcatcher/crashcatcher.hpp
@@ -4,7 +4,7 @@
 #include <string>
 
 #if (defined(__APPLE__) || (defined(__linux)  &&  !defined(ANDROID)) || (defined(__unix) &&  !defined(ANDROID)) || defined(__posix))
-    #define USE_CRASH_CATCHER 1
+    #define USE_CRASH_CATCHER 0
 #else
     #define USE_CRASH_CATCHER 0
 #endif


### PR DESCRIPTION
This new crash catcher is preventing TES3MP from building on GNU/Linux
`components/crashcatcher/crashcatcher.cpp:23:28: fatal error: SDL_messagebox.h: No such file or directory`
Disable it until the developers isolate the issue and patch it