### PR TITLE
Fix crash when equipping item on linux

### DIFF
--- a/apps/openmw/mwmp/processors/player/ProcessorPlayerItemUse.hpp
+++ b/apps/openmw/mwmp/processors/player/ProcessorPlayerItemUse.hpp
@@ -28,9 +28,12 @@ namespace mwmp
 
             if (!isRequest())
             {
-                LOG_APPEND(Log::LOG_INFO, "- refId: %s, count: %i, charge: %f, enchantmentCharge: %f, soul: %s",
+                // Due to a bug on Linux w/ vsnprintf, we have to append soul as string here instead
+                std::string msgStr = "- refId: %s, count: %i, charge: %f, enchantmentCharge: %f, soul: " + player->usedItem.soul;
+                LOG_APPEND(Log::LOG_INFO, msgStr.c_str(),
                     player->usedItem.refId.c_str(), player->usedItem.count, player->usedItem.charge,
-                    player->usedItem.enchantmentCharge, player->usedItem.soul.c_str());
+                    player->usedItem.enchantmentCharge);
+
 
                 MWWorld::Ptr playerPtr = MWBase::Environment::get().getWorld()->getPlayerPtr();
                 MWWorld::InventoryStore &inventoryStore = playerPtr.getClass().getInventoryStore(playerPtr);


### PR DESCRIPTION
its caused by some weird issue in vsnprintf on linux when using strings, didnt dive too deeply into it since dont have much free time atm - but this atleast resolves it. not sure if there is a proper solution, this is more of a workaround