### PR TITLE
Update link to TES3MP section on OpenMW forums

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Getting Started
 
 * [Quickstart guide](https://github.com/TES3MP/openmw-tes3mp/wiki/Quickstart-guide)
 * [Steam group](https://steamcommunity.com/groups/mwmulti) and its [detailed FAQ](https://steamcommunity.com/groups/mwmulti/discussions/1/353916184342480541/)
-* [TES3MP section on OpenMW forums](https://forum.openmw.org/viewforum.php?f=44)
+* [TES3MP section on OpenMW forums](https://forum.openmw.org/viewforum.php?f=45)
 * [Subreddit](https://www.reddit.com/r/tes3mp)
 * [Known issues and bug reports](https://github.com/TES3MP/openmw-tes3mp/issues)
 


### PR DESCRIPTION
URL changed as TES3MP is no longer it's own section but instead falls under new umbrella section.

I think this is the smallest change I have ever made a pull request for.

Maybe also make same change on 0.7.0 branch.