### PR TITLE
[Client] Don't switch between walking and running states whenever text input is active

### DIFF
--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -1260,6 +1260,16 @@ namespace MWInput
 
     void InputManager::toggleWalking()
     {
+        /*
+            Start of tes3mp addition
+            
+            Don't switch between walking states while text input is active
+        */
+        if (SDL_IsTextInputActive()) return;
+        /*
+            End of tes3mp addition
+        */
+
         if (MWBase::Environment::get().getWindowManager()->isGuiMode()) return;
         mAlwaysRunActive = !mAlwaysRunActive;
 


### PR DESCRIPTION
Fixes #494.