### PR TITLE
Make link to changelog work again

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Font Licenses:
 Project Status
 --------------
 
-[Version changelog](https://github.com/TES3MP/openmw-tes3mp/blob/master/tes3mp-changelog.md)
+[Version changelog](https://github.com/TES3MP/openmw-tes3mp/blob/0.7.0/tes3mp-changelog.md)
 
 As of version 0.7.0, TES3MP is fully playable, providing very extensive player, NPC, world and quest synchronization, as well as state saving and loading, all of which are highly customizable via [serverside Lua scripts](https://github.com/TES3MP/CoreScripts).
 


### PR DESCRIPTION
since master branch is gone and we are on 0.7.0 now, the URL had to be changed.