### PR TITLE
[General] Update positions for dead players on other clients

### DIFF
--- a/apps/openmw-mp/processors/player/ProcessorPlayerPosition.hpp
+++ b/apps/openmw-mp/processors/player/ProcessorPlayerPosition.hpp
@@ -1,7 +1,3 @@
-//
-// Created by koncord on 31.03.17.
-//
-
 #ifndef OPENMW_PROCESSORPLAYERPOSITION_HPP
 #define OPENMW_PROCESSORPLAYERPOSITION_HPP
 
@@ -19,11 +15,7 @@ namespace mwmp
 
         void Do(PlayerPacket &packet, Player &player) override
         {
-            //DEBUG_PRINTF(strPacketID);
-            if (!player.creatureStats.mDead)
-            {
-                player.sendToLoaded(&packet);
-            }
+            player.sendToLoaded(&packet);
         }
     };
 }

--- a/apps/openmw/mwmp/DedicatedPlayer.cpp
+++ b/apps/openmw/mwmp/DedicatedPlayer.cpp
@@ -71,6 +71,13 @@ DedicatedPlayer::~DedicatedPlayer()
 
 void DedicatedPlayer::update(float dt)
 {
+    // Only move and set anim flags if the framerate isn't too low
+    if (dt < 0.1)
+    {
+        move(dt);
+        setAnimFlags();
+    }
+
     MWMechanics::CreatureStats *ptrCreatureStats = &ptr.getClass().getCreatureStats(ptr);
 
     MWMechanics::DynamicStat<float> value;
@@ -100,13 +107,6 @@ void DedicatedPlayer::update(float dt)
     ptrCreatureStats->setAiSetting(MWMechanics::CreatureStats::AI_Fight, 0);
     ptrCreatureStats->setAiSetting(MWMechanics::CreatureStats::AI_Flee, 0);
     ptrCreatureStats->setAiSetting(MWMechanics::CreatureStats::AI_Hello, 0);
-
-    // Only move and set anim flags if the framerate isn't too low
-    if (dt < 0.1)
-    {
-        move(dt);
-        setAnimFlags();
-    }
 }
 
 void DedicatedPlayer::move(float dt)


### PR DESCRIPTION
Dead players will now show up at the correct cell and position for living players, making server scripts that allow players to revive each other much more functional.