### PR TITLE
[Server] Fix credentials generation to make testing possible.

### DIFF
--- a/apps/openmw-mp/Script/Functions/Miscellaneous.cpp
+++ b/apps/openmw-mp/Script/Functions/Miscellaneous.cpp
@@ -17,9 +17,10 @@ const char *MiscellaneousFunctions::GenerateRandomString(unsigned int length) no
 
     std::random_device randomDevice;
     std::mt19937 generator(randomDevice());
-    std::uniform_int_distribution<> distribution(0, characters.size() - 1);
+    std::uniform_int_distribution<std::mt19937::result_type> distribution(0, characters.size() - 1);
 
-    std::string randomString;
+    /* WARNING: this function is no longer reentrant with a static variable */
+    static std::string randomString;
 
     for (std::size_t i = 0; i < length; ++i)
     {
@@ -31,7 +32,8 @@ const char *MiscellaneousFunctions::GenerateRandomString(unsigned int length) no
 
 const char *MiscellaneousFunctions::GetSHA256Hash(const char* inputString) noexcept
 {
-    std::string hashString = picosha2::hash256_hex_string(std::string{inputString});
+    /* WARNING: this function is no longer reentrant with a static variable */
+    static std::string hashString = picosha2::hash256_hex_string(std::string{inputString});
 
     return hashString.c_str();
 }

--- a/apps/openmw-mp/Script/Functions/Miscellaneous.hpp
+++ b/apps/openmw-mp/Script/Functions/Miscellaneous.hpp
@@ -28,6 +28,7 @@ public:
 
     /**
     * \brief Get the SHA256 hash corresponding to an input string.
+    * \details function is not reentrant due to a static variable
     *
     * \param inputString The input string.
     * \return The SHA256 hash.
@@ -36,6 +37,7 @@ public:
 
     /**
     * \brief Get the last player ID currently connected to the server.
+    * \details function is not reentrant due to a static variable
     *
     * Every player receives a unique numerical index known as their player ID upon joining the
     * server.


### PR DESCRIPTION
Fix cannot log in after password hashing implemented (server)
- Fixed behaviour: wrong credentials generation.
- Fixed functions: GenerateRandomString, GetSHA256Hash.
- Rootcaouse: The rootcause was string objects getting out ot of scope and returning .c_str(). Static variable was used as a workaround.

Possible issues:
- This is safe until the functions will need to be reentrant.

Performed tests:
- Before fix not albe to log in correctly most of the times, random behavoiur, server crashing.
- Able to correctly register, log in and out multiple times.
- Checked data/player/name.json player file, after the fix the hash is stored correctly in ASCII, without any unicode characters.