### PR TITLE
[Client] Assign summoned creatures' actorId correctly, skipping those already assigned

### DIFF
--- a/apps/openmw/mwmechanics/creaturestats.cpp
+++ b/apps/openmw/mwmechanics/creaturestats.cpp
@@ -751,7 +751,7 @@ namespace MWMechanics
     {
         for (std::map<CreatureStats::SummonKey, int>::iterator it = mSummonedCreatures.begin(); it != mSummonedCreatures.end(); )
         {
-            if (Misc::StringUtils::ciEqual(getSummonedCreature(it->first.first), refId))
+            if (Misc::StringUtils::ciEqual(getSummonedCreature(it->first.first), refId) && it->second == -1)
             {
                 it->second = actorId;
                 break;

--- a/apps/openmw/mwmp/ObjectList.cpp
+++ b/apps/openmw/mwmp/ObjectList.cpp
@@ -495,7 +495,9 @@ void ObjectList::spawnObjects(MWWorld::CellStore* cellStore)
                     LOG_APPEND(TimedLog::LOG_INFO, "-- adding active spell to master with id %s, effect %i, duration %f",
                         baseObject.summonSpellId.c_str(), baseObject.summonEffectId, baseObject.summonDuration);
 
-                    masterCreatureStats.getActiveSpells().addSpell(baseObject.summonSpellId, false, activeEffects, "", masterCreatureStats.getActorId());
+                    auto activeSpells = masterCreatureStats.getActiveSpells();
+                    if (!activeSpells.isSpellActive(baseObject.summonSpellId))
+                        activeSpells.addSpell(baseObject.summonSpellId, false, activeEffects, "", masterCreatureStats.getActorId());
 
                     LOG_APPEND(TimedLog::LOG_INFO, "-- setting summoned creatureActorId for %i-%i to %i",
                         newPtr.getCellRef().getRefNum(), newPtr.getCellRef().getMpNum(), creatureActorId);

--- a/components/openmw-mp/Base/BasePacketProcessor.hpp
+++ b/components/openmw-mp/Base/BasePacketProcessor.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <memory>
 #include <unordered_map>
+#include <stdexcept>
 
 #define BPP_INIT(packet_id) packetID = packet_id; strPacketID = #packet_id; className = typeid(this).name(); avoidReading = false;
 


### PR DESCRIPTION
Long term, we probably need a packet structure change. Currently summons' actorId is received from ObjectSpawn packet, which lacks the information about the original effect and spell id. So instead of using the spell->creature map properly, we simply iterate over it and assign actorId to whatever matches the creature type. That can cause issues due to packet ordering even with this fix in place.