### PR TITLE
[Buildsys] Do not require Bullet when building only the server component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,6 +329,11 @@ if (WIN32)
     add_definitions(-DNOMINMAX -DWIN32_LEAN_AND_MEAN)
 endif()
 
+# Start of tes3mp addition
+#
+# Don't require certain dependencies for the server
+IF(BUILD_OPENMW OR BUILD_OPENCS)
+# End of tes3mp addition
 if(OPENMW_USE_SYSTEM_BULLET)
     set(REQUIRED_BULLET_VERSION 286) # Bullet 286 required due to runtime bugfixes for btCapsuleShape
     if (DEFINED ENV{TRAVIS_BRANCH} OR DEFINED ENV{APPVEYOR})
@@ -361,6 +366,11 @@ if(OPENMW_USE_SYSTEM_BULLET)
         message(FATAL_ERROR "Bullet does not uses double precision")
     endif()
 endif()
+# Start of tes3mp addition
+#
+# Don't require certain dependencies for the server
+ENDIF(BUILD_OPENMW OR BUILD_OPENCS)
+# End of tes3mp addition
 
 if (NOT WIN32 AND BUILD_WIZARD) # windows users can just run the morrowind installer
     find_package(LIBUNSHIELD REQUIRED) # required only for non win32 when building openmw-wizard


### PR DESCRIPTION
Building the server component, with the following configuration;
```
        cmake .. \
        -DCMAKE_BUILD_TYPE=Release \
        -DBUILD_OPENMW_MP=ON \
        -DBUILD_OPENMW=OFF \
        -DBUILD_OPENCS=OFF \
        -DBUILD_BROWSER=OFF \
        -DBUILD_BSATOOL=OFF \
        -DBUILD_ESMTOOL=OFF \
        -DBUILD_ESSIMPORTER=OFF \
        -DBUILD_LAUNCHER=OFF \
        -DBUILD_MWINIIMPORTER=OFF \
        -DBUILD_MYGUI_PLUGIN=OFF \
        -DBUILD_OPENMW=OFF \
        -DBUILD_WIZARD=OFF \
```
Has CMake still looking for Bullet;
```
-- Configuring OpenMW...
-- Found Git: /usr/bin/git (found version "2.26.3")
-- /tmp/CrabNet/include
-- /tmp/CrabNet/lib/libRakNetLibStatic.a
-- Found RakNet_LIBRARY_RELEASE: /tmp/CrabNet/lib/libRakNetLibStatic.a
-- Found RakNet_INCLUDES: /tmp/CrabNet/include/raknet
-- Found OpenGL: /usr/lib/libGL.so
-- Found LZ4: /usr/lib/liblz4.so
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:164 (message):
  Could NOT find Bullet (missing: BULLET_DYNAMICS_LIBRARY
  BULLET_COLLISION_LIBRARY BULLET_MATH_LIBRARY BULLET_SOFTBODY_LIBRARY
  BULLET_INCLUDE_DIR) (Required is at least version "286")
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:445 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake/Modules/FindBullet.cmake:83 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  CMakeLists.txt:351 (find_package)
  ```
  
  The addition of the following guards seems adequate.
  
  Please review.
  