### PR TITLE
[Buildsys] Tweaks to allow server-only builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -390,6 +390,12 @@ if(NOT HAVE_STDINT_H)
     message(FATAL_ERROR "stdint.h was not found" )
 endif()
 
+# Start of tes3mp addition
+#
+# Don't require certain dependencies for the server
+# but keep OSG's headers (HACK)
+IF(BUILD_OPENMW OR BUILD_OPENCS)
+# End of tes3mp addition
 if(OPENMW_USE_SYSTEM_OSG)
     find_package(OpenSceneGraph 3.4.0 REQUIRED ${USED_OSG_COMPONENTS})
     if (${OPENSCENEGRAPH_VERSION} VERSION_GREATER 3.6.2 AND ${OPENSCENEGRAPH_VERSION} VERSION_LESS 3.6.5)
@@ -406,12 +412,15 @@ include_directories(BEFORE SYSTEM ${OPENSCENEGRAPH_INCLUDE_DIRS})
 if(OSG_STATIC)
     add_definitions(-DOSG_LIBRARY_STATIC)
 endif()
-
 # Start of tes3mp addition
 #
 # Don't require certain dependencies for the server
-IF(BUILD_OPENMW OR BUILD_OPENCS)
+# but keep OSG's headers (HACK)
+ELSE(BUILD_OPENMW OR BUILD_OPENCS)
+    include_directories(${OPENSCENEGRAPH_INCLUDE_DIRS})
+ENDIF(BUILD_OPENMW OR BUILD_OPENCS)
 # End of tes3mp addition
+
 set(BOOST_COMPONENTS system filesystem program_options iostreams)
 if(WIN32)
     set(BOOST_COMPONENTS ${BOOST_COMPONENTS} locale)
@@ -429,10 +438,25 @@ endif()
 set(Boost_NO_BOOST_CMAKE ON)
 
 find_package(Boost 1.6.2 REQUIRED COMPONENTS ${BOOST_COMPONENTS} OPTIONAL_COMPONENTS ${BOOST_OPTIONAL_COMPONENTS})
+# Start of tes3mp addition
+#
+# Don't require certain dependencies for the server
+IF(BUILD_OPENMW OR BUILD_OPENCS)
+# End of tes3mp addition
 if(OPENMW_USE_SYSTEM_MYGUI)
     find_package(MyGUI 3.2.2 REQUIRED)
 endif()
+# End of tes3mp addition
+#
+# Don't require certain dependencies for the server
+ENDIF(BUILD_OPENMW OR BUILD_OPENCS)
+# End of tes3mp addition
 find_package(SDL2 2.0.9 REQUIRED)
+# Start of tes3mp addition
+#
+# Don't require certain dependencies for the server
+IF(BUILD_OPENMW OR BUILD_OPENCS)
+# End of tes3mp addition
 find_package(OpenAL REQUIRED)
 # End of tes3mp addition
 #
@@ -578,7 +602,17 @@ IF(BUILD_OPENMW OR BUILD_OPENCS)
 # End of tes3mp addition
 add_subdirectory (extern/osg-ffmpeg-videoplayer)
 add_subdirectory (extern/oics)
+# Start of tes3mp addition
+#
+# Don't require certain dependencies for the server
+ENDIF(BUILD_OPENMW OR BUILD_OPENCS)
+# End of tes3mp addition
 add_subdirectory (extern/Base64)
+# Start of tes3mp addition
+#
+# Don't require certain dependencies for the server
+IF(BUILD_OPENMW OR BUILD_OPENCS)
+# End of tes3mp addition
 if (BUILD_OPENCS)
     add_subdirectory (extern/osgQt)
 endif()

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -32,6 +32,11 @@ add_component_dir (settings
     settings parser
     )
 
+# Start of tes3mp change
+#
+# Don't include certain components in server-only builds
+IF (BUILD_OPENMW OR BUILD_OPENCS)
+# End of tes3mp change
 add_component_dir (bsa
     bsa_file compressedbsafile memorystream
     )
@@ -39,8 +44,7 @@ add_component_dir (bsa
 add_component_dir (vfs
     manager archive bsaarchive filesystemarchive registerarchives
     )
-	
-IF(BUILD_OPENMW OR BUILD_OPENCS)
+
 add_component_dir (resource
     scenemanager keyframemanager imagemanager bulletshapemanager bulletshape niffilemanager objectcache multiobjectcache resourcesystem
     resourcemanager stats animation
@@ -67,7 +71,11 @@ add_component_dir (nifosg
 add_component_dir (nifbullet
     bulletnifloader
     )
-ENDIF(BUILD_OPENMW OR BUILD_OPENCS)
+# Start of tes3mp change
+#
+# Don't include certain components in server-only builds
+ENDIF (BUILD_OPENMW OR BUILD_OPENCS)
+# End of tes3mp change
 
 add_component_dir (to_utf8
     to_utf8
@@ -84,9 +92,19 @@ add_component_dir (esm
     aisequence magiceffects util custommarkerstate stolenitems transport animationstate controlsstate mappings
     )
 
+# Start of tes3mp change
+#
+# Don't include certain components in server-only builds
+IF (BUILD_OPENMW OR BUILD_OPENCS)
+# End of tes3mp change
 add_component_dir (esmterrain
     storage
     )
+# Start of tes3mp change
+#
+# Don't include certain components in server-only builds
+ENDIF (BUILD_OPENMW OR BUILD_OPENCS)
+# End of tes3mp change
 
 add_component_dir (misc
     constants utf8stream stringops resourcehelpers rng messageformatparser weakcache thread
@@ -100,6 +118,7 @@ IF(NOT WIN32 AND NOT APPLE)
     add_definitions(-DGLOBAL_DATA_PATH="${GLOBAL_DATA_PATH}")
     add_definitions(-DGLOBAL_CONFIG_PATH="${GLOBAL_CONFIG_PATH}")
 ENDIF()
+
 add_component_dir (files
     linuxpath androidpath windowspath macospath fixedpath multidircollection collections configurationmanager escape
     lowlevelfile constrainedfilestream memorystream
@@ -121,6 +140,11 @@ add_component_dir (translation
     translation
     )
 
+# Start of tes3mp addition
+#
+# Don't include certain components in server-only builds
+IF (BUILD_OPENMW OR BUILD_OPENCS)
+# End of tes3mp change
 add_component_dir (terrain
     storage world buffercache defs terraingrid material terraindrawable texturemanager chunkmanager compositemaprenderer quadtreeworld quadtreenode viewdata cellborder
     )
@@ -128,8 +152,7 @@ add_component_dir (terrain
 add_component_dir (loadinglistener
     loadinglistener
     )
-	
-IF(BUILD_OPENMW OR BUILD_OPENCS)
+
 add_component_dir (myguiplatform
     myguirendermanager myguidatamanager myguiplatform myguitexture myguiloglistener additivelayer scalinglayer
     )
@@ -145,7 +168,11 @@ add_component_dir (fontloader
 add_component_dir (sdlutil
     gl4es_init sdlgraphicswindow imagetosurface sdlinputwrapper sdlvideowrapper events sdlcursormanager
     )
-ENDIF(BUILD_OPENMW OR BUILD_OPENCS)
+# Start of tes3mp change
+#
+# Don't include certain components in server-only builds
+ENDIF (BUILD_OPENMW OR BUILD_OPENCS)
+# End of tes3mp change
 
 add_component_dir (version
     version
@@ -228,7 +255,7 @@ add_component_dir (fallback
 #
 # Don't require the crashcatcher when building on platforms other than Windows or when building only the server,
 # as it causes compilation problems
-if (BUILD_OPENMW OR BUILD_OPENCS)
+IF (BUILD_OPENMW OR BUILD_OPENCS)
     if(WIN32)
         add_component_dir (crashcatcher
             windows_crashcatcher
@@ -236,13 +263,13 @@ if (BUILD_OPENMW OR BUILD_OPENCS)
             windows_crashshm
         )
     endif()
-endif()
+ENDIF (BUILD_OPENMW OR BUILD_OPENCS)
 # End of tes3mp change (major)
 
 # Start of tes3mp change (major)
 #
 # Don't require the DetourNavigator when building the server
-if (BUILD_OPENMW OR BUILD_OPENCS)
+IF (BUILD_OPENMW OR BUILD_OPENCS)
     add_component_dir(detournavigator
             debug
             makenavmesh
@@ -265,7 +292,7 @@ if (BUILD_OPENMW OR BUILD_OPENCS)
             oscillatingrecastmeshobject
             offmeshconnectionsmanager
             )
-endif()
+ENDIF (BUILD_OPENMW OR BUILD_OPENCS)
 # End of tes3mp change (major)
 
 set (ESM_UI ${CMAKE_SOURCE_DIR}/files/ui/contentselector.ui
@@ -274,7 +301,8 @@ set (ESM_UI ${CMAKE_SOURCE_DIR}/files/ui/contentselector.ui
 # Start of tes3mp change (major)
 #
 # Don't require Qt when building the server
-if (BUILD_OPENMW OR BUILD_OPENCS)
+IF (BUILD_OPENMW OR BUILD_OPENCS)
+# End of tes3mp change
 if (USE_QT)
     add_component_qt_dir (contentselector
         model/modelitem model/esmfile
@@ -299,8 +327,11 @@ if (USE_QT)
     QT5_WRAP_UI(ESM_UI_HDR ${ESM_UI})
     QT5_WRAP_CPP(MOC_SRCS ${COMPONENT_MOC_FILES})
 endif()
-endif(BUILD_OPENMW OR BUILD_OPENCS)
-# End of tes3mp change (major)
+# Start of tes3mp change (major)
+#
+# Don't require Qt when building the server
+ENDIF (BUILD_OPENMW OR BUILD_OPENCS)
+# End of tes3mp change
 
 if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64" AND NOT APPLE)
@@ -314,8 +345,8 @@ add_library(components STATIC ${COMPONENT_FILES} ${MOC_SRCS} ${ESM_UI_HDR})
 
 # Start of tes3mp change (major)
 #
-# Don't require OSG when building the server
-if (BUILD_OPENMW OR BUILD_OPENCS)
+# Don't require graphics related libs when building the server
+IF (BUILD_OPENMW OR BUILD_OPENCS)
 target_link_libraries(components
     # CMake's built-in OSG finder does not use pkgconfig, so we have to
     # manually ensure the order is correct for inter-library dependencies.
@@ -332,32 +363,33 @@ target_link_libraries(components
     ${OSG_LIBRARIES}
     ${OPENTHREADS_LIBRARIES}
 
-    ${Boost_SYSTEM_LIBRARY}
-    ${Boost_FILESYSTEM_LIBRARY}
-    ${Boost_PROGRAM_OPTIONS_LIBRARY}
-    ${Boost_IOSTREAMS_LIBRARY}
-
     ${SDL2_LIBRARIES}
     ${OPENGL_gl_LIBRARY}
     ${MyGUI_LIBRARIES}
     LZ4::LZ4
     )
-endif()
+ENDIF (BUILD_OPENMW OR BUILD_OPENCS)
+target_link_libraries(components
+    ${Boost_SYSTEM_LIBRARY}
+    ${Boost_FILESYSTEM_LIBRARY}
+    ${Boost_PROGRAM_OPTIONS_LIBRARY}
+    ${Boost_IOSTREAMS_LIBRARY}
+    )
 # End of tes3mp change (major)
 
 # Start of tes3mp change (major)
 #
-# Don't require RecastNavigation, Base64 or Bullet when building the server
-if (BUILD_OPENMW OR BUILD_OPENCS)
+# Don't require RecastNavigation nor Bullet when building the server
+IF (BUILD_OPENMW OR BUILD_OPENCS)
     target_link_libraries(components
             RecastNavigation::DebugUtils
             RecastNavigation::Detour
             RecastNavigation::Recast
 
-            Base64
             ${BULLET_LIBRARIES}
             )
-endif ()
+ENDIF (BUILD_OPENMW OR BUILD_OPENCS)
+target_link_libraries(components Base64)
 # End of tes3mp change (major)
 
 if (WIN32)
@@ -369,12 +401,16 @@ endif()
 # Start of tes3mp change (major)
 #
 # Don't require Qt when building the server
+IF (BUILD_OPENMW OR BUILD_OPENCS)
+# End of tes3mp change
 if (USE_QT)
-if (BUILD_OPENMW OR BUILD_OPENCS)
     target_link_libraries(components Qt5::Widgets Qt5::Core)
 endif()
-endif()
-# End of tes3mp change (major)
+# Start of tes3mp change (major)
+#
+# Don't require Qt when building the server
+ENDIF (BUILD_OPENMW OR BUILD_OPENCS)
+# End of tes3mp change
 
 if (GIT_CHECKOUT)
     add_dependencies (components git-version)


### PR DESCRIPTION
Re-include Base64, Boost and SDL2[1]

Exclude OSG but keep its headers[2]

Exclude most non-essential components and their deps

This greatly reduces `tes3mp-server`'s requirements when built in isolation

```
$ ldd ./tes3mp-server | awk '{print $1}'
linux-vdso.so.1
libluajit-5.1.so.2
libdl.so.2
libpthread.so.0
libboost_system.so.1.67.0
libboost_filesystem.so.1.67.0
libboost_program_options.so.1.67.0
libboost_iostreams.so.1.67.0
libstdc++.so.6
libm.so.6
libgcc_s.so.1
libc.so.6
/lib64/ld-linux-x86-64.so.2
librt.so.1
libz.so.1
libbz2.so.1.0
```

[1] SDL2 is required by the debug component
May be worth deviating from upstream by making its inclusion
conditional in the future

[2] Server component requires declarations present in the OSG headers