### PR TITLE
Maybe fix console and chat window resizing/moving

### DIFF
--- a/apps/openmw/mwvr/vrgui.cpp
+++ b/apps/openmw/mwvr/vrgui.cpp
@@ -529,6 +529,8 @@ namespace MWVR
         LayerConfig mapWindowConfig = createSideBySideConfig(3);
         LayerConfig inventoryCompanionWindowConfig = createSideBySideConfig(4);
         LayerConfig dialogueWindowConfig = createSideBySideConfig(5);
+        LayerConfig chatWindowConfig = createSideBySideConfig(6);
+        LayerConfig consoleWindowConfig = createSideBySideConfig(7);
 
         osg::Vec3 leftHudOffset = gLeftHudOffsetWrist;
 
@@ -605,6 +607,8 @@ namespace MWVR
             {"Menu", videoPlayerConfig},
             {"LoadingScreen", loadingScreenConfig},
             {"VirtualKeyboard", virtualKeyboardConfig},
+            {"Chat", chatWindowConfig},
+            {"Console", consoleWindowConfig},
         };
     }
 

--- a/files/mygui/openmw_console.layout
+++ b/files/mygui/openmw_console.layout
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <MyGUI type="Layout">
-  <Widget type="Window" skin="MW_Window" position="0 0 400 400" layer="Windows" name="_Main">
+  <Widget type="Window" skin="MW_Window" position="0 0 400 400" layer="Console" name="_Main">
     <Property key="Caption" value="#{sConsoleTitle}"/>
     <Property key="MinSize" value="40 40"/>
     <Property key="Visible" value="false"/>

--- a/files/mygui/openmw_layers.xml
+++ b/files/mygui/openmw_layers.xml
@@ -19,4 +19,6 @@
     <Layer name="MessageBox" overlapped="false" pick="true"/>
     <Layer name="InputBlocker" overlapped="false" pick="true"/>
     <Layer name="Pointer" overlapped="false" pick="false"/>
+    <Layer name="Console" overlapped="true" pick="true"/>
+    <Layer name="Chat" overlapped="true" pick="true"/>
 </MyGUI>

--- a/files/mygui/openmw_layers_vr.xml
+++ b/files/mygui/openmw_layers_vr.xml
@@ -30,4 +30,6 @@
     <Layer name="VideoPlayer" overlapped="false" pick="true"/>
     <Layer name="VirtualKeyboard" overlapped="false" pick="true"/>
     <Layer name="Pointer" overlapped="false" pick="false"/>
+    <Layer name="Console" overlapped="true" pick="true"/>
+    <Layer name="Chat" overlapped="true" pick="true"/>
 </MyGUI>

--- a/files/mygui/tes3mp_chat.layout
+++ b/files/mygui/tes3mp_chat.layout
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <MyGUI type="Layout">
-  <Widget type="Window" skin="MW_Window" position="0 0 400 400" layer="Windows" name="_Main">
+  <Widget type="Window" skin="MW_Window" position="0 0 400 400" layer="Chat" name="_Main">
     <Property key="Caption" value="#{sConsoleTitle}"/>
     <Property key="MinSize" value="40 40"/>
     <Property key="Visible" value="false"/>


### PR DESCRIPTION
Including them in my side-by-side logic they should be effectively unmoveable and unresizeable, which should avoid the problem, but also forces the window to be more dominable.

Since it's part of the side-by-side config: A possible next step is to make the chat window visible whenever the player opens the inventory, and it'll act as a fifth window in the setup.