### PR TITLE
[Documentation] Update some docs to match method signatures

### DIFF
--- a/apps/openmw-mp/Script/Functions/Actors.hpp
+++ b/apps/openmw-mp/Script/Functions/Actors.hpp
@@ -828,7 +828,7 @@ public:
     /**
     * \brief Set the distance of the AI package associated with the current AI action.
     *
-    * \param duration The distance of the package.
+    * \param distance The distance of the package.
     * \return void
     */
     static void SetActorAIDistance(unsigned int distance) noexcept;

--- a/apps/openmw-mp/Script/Functions/Dialogue.hpp
+++ b/apps/openmw-mp/Script/Functions/Dialogue.hpp
@@ -77,7 +77,7 @@ public:
     * \param groupname The groupname of the animation.
     * \param mode The mode of the animation.
     * \param count The number of times the animation should be played.
-    * \param bool Whether the animation should persist or not.
+    * \param persist Whether the animation should persist or not.
     * \return void
     */
     static void PlayAnimation(unsigned short pid, const char* groupname, int mode, int count, bool persist) noexcept;

--- a/apps/openmw-mp/Script/Functions/GUI.hpp
+++ b/apps/openmw-mp/Script/Functions/GUI.hpp
@@ -116,7 +116,7 @@ public:
     *
     * \param pid The player ID whose quick key changes should be used.
     * \param slot The slot to be used.
-    * \param slot The type of the quick key (0 for ITEM, 1 for ITEM_MAGIC, 2 for MAGIC, 3 for UNASSIGNED).
+    * \param type The type of the quick key (0 for ITEM, 1 for ITEM_MAGIC, 2 for MAGIC, 3 for UNASSIGNED).
     * \param itemId The itemId of the item.
     * \return void
     */

--- a/apps/openmw-mp/Script/Functions/Mechanics.hpp
+++ b/apps/openmw-mp/Script/Functions/Mechanics.hpp
@@ -286,9 +286,9 @@ public:
     * \param jailDays The number of days to spend jailed, where each day affects one skill point.
     * \param ignoreJailTeleportation Whether the player being teleported to the nearest jail
     *                                marker should be overridden.
-    * \param ignoreJailSkillIncrease Whether the player's Sneak and Security skills should be
-    *                                prevented from increasing as a result of the jailing,
-    *                                overriding default behavior.
+    * \param ignoreJailSkillIncreases Whether the player's Sneak and Security skills should be
+    *                                 prevented from increasing as a result of the jailing,
+    *                                 overriding default behavior.
     * \param jailProgressText The text that should be displayed while jailed.
     * \param jailEndText The text that should be displayed once the jailing period is over.
     * \return void

--- a/apps/openmw-mp/Script/Functions/Objects.hpp
+++ b/apps/openmw-mp/Script/Functions/Objects.hpp
@@ -723,7 +723,7 @@ public:
     * \brief Get the number of client local variables of the object at a certain index in the
     * read object list.
     *
-    * \param index The index of the object.
+    * \param objectIndex The index of the object.
     * \return The number of client local variables.
     */
     static unsigned int GetClientLocalsSize(unsigned int objectIndex) noexcept;
@@ -742,7 +742,7 @@ public:
     * \brief Get the type of the client local variable at a certain variableIndex in the client locals
     * of the object at a certain objectIndex in the read object list.
     *
-    * \param index The index of the object.
+    * \param objectIndex The index of the object.
     * \param variableIndex The index of the client local.
     * \return The variable type (0 for INTEGER, 1 for LONG, 2 for FLOAT).
     */
@@ -752,7 +752,7 @@ public:
     * \brief Get the integer value of the client local variable at a certain variableIndex in the client
     * locals of the object at a certain objectIndex in the read object list.
     *
-    * \param index The index of the object.
+    * \param objectIndex The index of the object.
     * \param variableIndex The index of the client local.
     * \return The integer value.
     */
@@ -762,7 +762,7 @@ public:
     * \brief Get the float value of the client local variable at a certain variableIndex in the client
     * locals of the object at a certain objectIndex in the read object list.
     *
-    * \param index The index of the object.
+    * \param objectIndex The index of the object.
     * \param variableIndex The index of the client local.
     * \return The float value.
     */
@@ -881,8 +881,8 @@ public:
     /**
     * \brief Set the container subaction type of the temporary object list stored on the server.
     *
-    * \param action The action type (0 for NONE, 1 for DRAG, 2 for DROP, 3 for TAKE_ALL,
-    *               4 for REPLY_TO_REQUEST, 5 for RESTOCK_RESULT).
+    * \param subAction The action type (0 for NONE, 1 for DRAG, 2 for DROP, 3 for TAKE_ALL,
+    *                  4 for REPLY_TO_REQUEST, 5 for RESTOCK_RESULT).
     * \return void
     */
     static void SetObjectListContainerSubAction(unsigned char subAction) noexcept;
@@ -960,7 +960,7 @@ public:
     *
     * Object durabilities are set through this value.
     *
-    * \param charge The enchantment charge.
+    * \param enchantmentCharge The enchantment charge.
     * \return void
     */
     static void SetObjectEnchantmentCharge(double enchantmentCharge) noexcept;
@@ -1062,7 +1062,7 @@ public:
     /**
     * \brief Set the droppedByPlayer state of the temporary object stored on the server.
     *
-    * \param droppedByPlayer Whether the object has been dropped by a player or not.
+    * \param dropedByPlayerState Whether the object has been dropped by a player or not.
     * \return void
     */
     static void SetObjectDroppedByPlayerState(bool dropedByPlayerState) noexcept;
@@ -1247,7 +1247,7 @@ public:
     /**
     * \brief Set the enchantment charge of the temporary container item stored on the server.
     *
-    * \param charge The enchantment charge.
+    * \param enchantmentCharge The enchantment charge.
     * \return void
     */
     static void SetContainerItemEnchantmentCharge(double enchantmentCharge) noexcept;
@@ -1255,7 +1255,7 @@ public:
     /**
     * \brief Set the soul of the temporary container item stored on the server.
     *
-    * \param refId The soul.
+    * \param soul The soul.
     * \return void
     */
     static void SetContainerItemSoul(const char* soul) noexcept;
@@ -1354,9 +1354,10 @@ public:
     /**
     * \brief Send an ObjectDelete packet.
     *
-    * \param broadcast Whether this packet should be sent only to the player for whom the current
-    *                  object list was initialized or to everyone on the server.
-    *
+    * \param sendToOtherPlayers Whether this packet should be sent to players other than the
+    *                           player attached to the packet (false by default).
+    * \param skipAttachedPlayer Whether the packet should skip being sent to the player attached
+    *                           to the packet (false by default).
     * \return void
     */
     static void SendObjectDelete(bool sendToOtherPlayers, bool skipAttachedPlayer) noexcept;
@@ -1371,6 +1372,7 @@ public:
     * \return void
     */
     static void SendObjectLock(bool sendToOtherPlayers, bool skipAttachedPlayer) noexcept;
+
     /**
     * \brief Send an ObjectDialogueChoice packet.
     *
@@ -1407,9 +1409,10 @@ public:
     /**
     * \brief Send an ObjectTrap packet.
     *
-    * \param broadcast Whether this packet should be sent only to the player for whom the current
-    *                  object list was initialized or to everyone on the server.
-    *
+    * \param sendToOtherPlayers Whether this packet should be sent to players other than the
+    *                           player attached to the packet (false by default).
+    * \param skipAttachedPlayer Whether the packet should skip being sent to the player attached
+    *                           to the packet (false by default).
     * \return void
     */
     static void SendObjectTrap(bool sendToOtherPlayers, bool skipAttachedPlayer) noexcept;

--- a/apps/openmw-mp/Script/Functions/Quests.hpp
+++ b/apps/openmw-mp/Script/Functions/Quests.hpp
@@ -66,9 +66,9 @@ public:
     * \param quest The quest of the journal item.
     * \param index The quest index of the journal item.
     * \param actorRefId The actor refId of the journal item.
-    * \param The daysPassed for the journal item.
-    * \param The month for the journal item.
-    * \param The day of the month for the journal item.
+    * \param daysPassed The daysPassed for the journal item.
+    * \param month The month for the journal item.
+    * \param day The day of the month for the journal item.
     * \return void
     */
     static void AddJournalEntryWithTimestamp(unsigned short pid, const char* quest, unsigned int index, const char* actorRefId,

--- a/apps/openmw-mp/Script/Functions/RecordsDynamic.hpp
+++ b/apps/openmw-mp/Script/Functions/RecordsDynamic.hpp
@@ -440,7 +440,7 @@ public:
     * \brief Set the subtype of the temporary record stored on the server for
     * the currently specified record type.
     *
-    * \param type The spell type.
+    * \param subtype The spell type.
     * \return void
     */
     static void SetRecordSubtype(unsigned int subtype) noexcept;
@@ -557,7 +557,7 @@ public:
     * \brief Set the item quality of the temporary record stored on the server for the
     * currently specified record type.
     *
-    * \param weight The weight of the record.
+    * \param quality The quality of the record.
     * \return void
     */
     static void SetRecordQuality(double quality) noexcept;
@@ -584,7 +584,7 @@ public:
     * \brief Set the radius of the temporary record stored on the server for the currently
     * specified record type.
     *
-    * \param uses The radius of the record.
+    * \param radius The radius of the record.
     * \return void
     */
     static void SetRecordRadius(int radius) noexcept;
@@ -593,7 +593,9 @@ public:
     * \brief Set the color of the temporary record stored on the server for the currently
     * specified record type.
     *
-    * \param color The color of the record.
+    * \param red The red value of the record.
+    * \param green The green value of the record.
+    * \param blue The blue value of the record.
     * \return void
     */
     static void SetRecordColor(unsigned int red, unsigned int green, unsigned int blue) noexcept;
@@ -717,7 +719,7 @@ public:
     * \brief Set the head of the temporary record stored on the server for the
     * currently specified record type.
     *
-    * \param hair The head of the record.
+    * \param head The head of the record.
     * \return void
     */
     static void SetRecordHead(const char* head) noexcept;
@@ -726,7 +728,7 @@ public:
     * \brief Set the gender of the temporary record stored on the server for the
     * currently specified record type (0 for female, 1 for male).
     *
-    * \param hair The race of the record.
+    * \param gender The gender of the record.
     * \return void
     */
     static void SetRecordGender(unsigned int gender) noexcept;
@@ -735,7 +737,7 @@ public:
     * \brief Set the race of the temporary record stored on the server for the
     * currently specified record type.
     *
-    * \param hair The race of the record.
+    * \param race The race of the record.
     * \return void
     */
     static void SetRecordRace(const char* race) noexcept;
@@ -744,7 +746,7 @@ public:
     * \brief Set the character class of the temporary record stored on the server
     * for the currently specified record type.
     *
-    * \param hair The character class of the record.
+    * \param charClass The character class of the record.
     * \return void
     */
     static void SetRecordClass(const char* charClass) noexcept;
@@ -879,7 +881,7 @@ public:
     * \brief Set the minimum range of the temporary record stored on the server for the currently
     * specified record type.
     *
-    * \param volume The minimum range of the record.
+    * \param minRange The minimum range of the record.
     * \return void
     */
     static void SetRecordMinRange(double minRange) noexcept;
@@ -888,7 +890,7 @@ public:
     * \brief Set the maximum range of the temporary record stored on the server for the currently
     * specified record type.
     *
-    * \param volume The maximum range of the record.
+    * \param maxRange The maximum range of the record.
     * \return void
     */
     static void SetRecordMaxRange(double maxRange) noexcept;
@@ -1070,7 +1072,7 @@ public:
     /**
     * \brief Set the id of the of the temporary inventory item stored on the server.
     *
-    * \param partId The id of the inventory item.
+    * \param itemId The id of the inventory item.
     * \return void
     */
     static void SetRecordInventoryItemId(const char* itemId) noexcept;

--- a/apps/openmw-mp/Script/Functions/Server.hpp
+++ b/apps/openmw-mp/Script/Functions/Server.hpp
@@ -205,7 +205,7 @@ public:
     /**
      * \brief Checking if the server requires a password to connect.
      *
-     * @return
+     * \return Whether the server requires a password
      */
     static bool HasPassword() noexcept;
 
@@ -230,7 +230,7 @@ public:
     /**
     * \brief Set the game mode of the server, as displayed in the server browser.
     *
-    * \param name The new game mode.
+    * \param gameMode The new game mode.
     * \return void
     */
     static void SetGameMode(const char* gameMode) noexcept;

--- a/apps/openmw-mp/Script/Functions/Shapeshift.hpp
+++ b/apps/openmw-mp/Script/Functions/Shapeshift.hpp
@@ -89,8 +89,6 @@ public:
     *
     * \param pid The player ID.
     * \param refId The creature refId.
-    * \param displaysCreatureName Whether the player's name appears as that of the creature
-    *                             when hovered over by others.
     * \return void
     */
     static void SetCreatureRefId(unsigned short pid, const char *refId) noexcept;

--- a/apps/openmw-mp/Script/Functions/Stats.hpp
+++ b/apps/openmw-mp/Script/Functions/Stats.hpp
@@ -335,7 +335,7 @@ public:
     * Although confusing, the term "skill increase" for this is taken from OpenMW itself.
     *
     * \param pid The player ID.
-    * \param skillId The attribute ID.
+    * \param attributeId The attribute ID.
     * \return The increase in the attribute caused by skills.
     */
     static int GetSkillIncrease(unsigned short pid, unsigned int attributeId) noexcept;
@@ -397,7 +397,7 @@ public:
     * \brief Set the model of a player.
     *
     * \param pid The player ID.
-    * \param name The new model of the player.
+    * \param model The new model of the player.
     * \return void
     */
     static void SetModel(unsigned short pid, const char *model) noexcept;
@@ -446,7 +446,7 @@ public:
     * \brief Set the base health of a player.
     *
     * \param pid The player ID.
-    * \param name The new base health of the player.
+    * \param value The new base health of the player.
     * \return void
     */
     static void SetHealthBase(unsigned short pid, double value) noexcept;
@@ -455,7 +455,7 @@ public:
     * \brief Set the current health of a player.
     *
     * \param pid The player ID.
-    * \param name The new current health of the player.
+    * \param value The new current health of the player.
     * \return void
     */
     static void SetHealthCurrent(unsigned short pid, double value) noexcept;
@@ -464,7 +464,7 @@ public:
     * \brief Set the base magicka of a player.
     *
     * \param pid The player ID.
-    * \param name The new base magicka of the player.
+    * \param value The new base magicka of the player.
     * \return void
     */
     static void SetMagickaBase(unsigned short pid, double value) noexcept;
@@ -473,7 +473,7 @@ public:
     * \brief Set the current magicka of a player.
     *
     * \param pid The player ID.
-    * \param name The new current magicka of the player.
+    * \param value The new current magicka of the player.
     * \return void
     */
     static void SetMagickaCurrent(unsigned short pid, double value) noexcept;
@@ -482,7 +482,7 @@ public:
     * \brief Set the base fatigue of a player.
     *
     * \param pid The player ID.
-    * \param name The new base fatigue of the player.
+    * \param value The new base fatigue of the player.
     * \return void
     */
     static void SetFatigueBase(unsigned short pid, double value) noexcept;
@@ -491,7 +491,7 @@ public:
     * \brief Set the current fatigue of a player.
     *
     * \param pid The player ID.
-    * \param name The new current fatigue of the player.
+    * \param value The new current fatigue of the player.
     * \return void
     */
     static void SetFatigueCurrent(unsigned short pid, double value) noexcept;
@@ -583,7 +583,7 @@ public:
     * Although confusing, the term "skill increase" for this is taken from OpenMW itself.
     *
     * \param pid The player ID.
-    * \param skillId The attribute ID.
+    * \param attributeId The attribute ID.
     * \param value The increase in the attribute caused by skills.
     * \return void
     */

--- a/apps/openmw-mp/Script/Functions/Worldstate.hpp
+++ b/apps/openmw-mp/Script/Functions/Worldstate.hpp
@@ -266,7 +266,7 @@ public:
     /**
     * \brief Set the region affected by the next WorldRegionAuthority packet sent.
     *
-    * \param region The region.
+    * \param authorityRegion The region.
     * \return void
     */
     static void SetAuthorityRegion(const char* authorityRegion) noexcept;
@@ -364,7 +364,6 @@ public:
     /**
     * \brief Set the world's time scale in the write-only worldstate stored on the server.
     *
-    * \param pid The player ID.
     * \param timeScale The time scale.
     * \return void
     */
@@ -592,8 +591,10 @@ public:
     *        worldstate.
     *
     * \param pid The player ID attached to the packet.
-    * \param broadcast Whether this packet should be sent only to the attached player
-    *                  or to all players on the server.
+    * \param sendToOtherPlayers Whether this packet should be sent to players other than the
+    *                           player attached to the packet (false by default).
+    * \param skipAttachedPlayer Whether the packet should skip being sent to the player attached
+    *                           to the packet (false by default).
     * \return void
     */
     static void SendWorldMap(unsigned short pid, bool sendToOtherPlayers, bool skipAttachedPlayer) noexcept;


### PR DESCRIPTION
I was going through generating type notations and found some inconsistencies. This fixes all that my generator caught.