### PR TITLE
Fix (Client): Add Rotation order for onObjectRotate Packet

### DIFF
--- a/apps/openmw/mwmp/ObjectList.cpp
+++ b/apps/openmw/mwmp/ObjectList.cpp
@@ -783,7 +783,7 @@ void ObjectList::rotateObjects(MWWorld::CellStore* cellStore)
                                ptrFound.getCellRef().getRefNum(), ptrFound.getCellRef().getMpNum());
 
             MWBase::Environment::get().getWorld()->rotateObject(ptrFound,
-                baseObject.position.rot[0], baseObject.position.rot[1], baseObject.position.rot[2]);
+                                                                baseObject.position.rot[0], baseObject.position.rot[1], baseObject.position.rot[2], MWBase::RotationFlag_none);
         }
     }
 }


### PR DESCRIPTION
This adds the `MWBase::RotationFlag_none` flag for `tes3mp.SendObjectRotate` that's needed since it was introduced here: https://github.com/TES3MP/TES3MP/commit/387bda5e2207023dedf23630ca90775169ca8399 for tes3mp 0.8.0

This resolves the issue initially reported here: https://gitlab.com/OpenMW/openmw/-/issues/6781
and Merge Request for the commit: https://gitlab.com/OpenMW/openmw/-/merge_requests/305

As well as the failed fix in CoreScripts here as the issue occurs on cell _**reload**_ and not just initial load:
https://github.com/TES3MP/CoreScripts/commit/096b6f16877bd7078aa3dfecaddbedb9975af865

---
I was unsure what branch to target so I used the default (0.8.1), as it seemed like it would be easier to cherry-pick than targeting 0.8.2