### PR TITLE
Fix `gcc-13` build failures: missing `<cstdint>` includes

### DIFF
--- a/apps/openmw/mwinput/controlswitch.hpp
+++ b/apps/openmw/mwinput/controlswitch.hpp
@@ -1,6 +1,7 @@
 #ifndef MWINPUT_CONTROLSWITCH_H
 #define MWINPUT_CONTROLSWITCH_H
 
+#include <cstdint>
 #include <map>
 #include <string>
 

--- a/components/misc/utf8stream.hpp
+++ b/components/misc/utf8stream.hpp
@@ -1,6 +1,7 @@
 #ifndef MISC_UTF8ITER_HPP
 #define MISC_UTF8ITER_HPP
 
+#include <cstdint>
 #include <cstring>
 #include <tuple>
 

--- a/components/openmw-mp/Utils.hpp
+++ b/components/openmw-mp/Utils.hpp
@@ -2,6 +2,7 @@
 #define UTILS_HPP
 
 #include <algorithm>
+#include <cstdint>
 #include <string>
 #include <sstream>
 #include <vector>


### PR DESCRIPTION
Without the change build fails on `gcc-13` as:

    In file included from /build/source/components/misc/stringops.hpp:8,
                     from /build/source/components/settings/settings.cpp:6:
    /build/source/components/misc/utf8stream.hpp:11:13: error: 'uint32_t' does not name a type
       11 |     typedef uint32_t UnicodeChar;
          |             ^~~~~~~~
    /build/source/components/misc/utf8stream.hpp:5:1: note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
        4 | #include <cstring>
      +++ |+#include <cstdint>