### PR TITLE
Rewrite cmake/FindRakNet.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,7 +196,7 @@ if (WIN32)
 endif()
 
 find_package(RakNet REQUIRED)
-include_directories(${RakNet_INCLUDES})
+include_directories(${RakNet_INCLUDE_DIRS})
 
 # Dependencies
 find_package(OpenGL REQUIRED)

--- a/cmake/FindRakNet.cmake
+++ b/cmake/FindRakNet.cmake
@@ -1,77 +1,111 @@
-# Comes form project edunetgames
-# - Try to find RakNet
-# Once done this will define
+# Copyright © 2024 backlabs1 <backlabs1@mailbox.org>
 #
-#  RakNet_FOUND - system has RakNet
-#  RakNet_INCLUDES - the RakNet include directory
-#  RakNet_LIBRARY - Link these to use RakNet
+# Distributed under the GNU General Public License version 3 as published by
+# the Free Software Foundation.
 
-FIND_LIBRARY (RakNet_LIBRARY_RELEASE NAMES RakNetLibStatic
-    PATHS
-    ENV LD_LIBRARY_PATH
-    ENV LIBRARY_PATH
-    /usr/lib64
-    /usr/lib
-    /usr/local/lib64
-    /usr/local/lib
-    /opt/local/lib
-    $ENV{RAKNET_ROOT}/lib
+#[=======================================================================[.rst:
+FindRakNet
+-------
+
+Finds the RakNet library.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported targets, if found:
+
+``RakNet::RakNet``
+  The RakNet library
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables:
+
+``RakNet_FOUND``
+  True if the system has the RakNet library.
+``RakNet_INCLUDE_DIRS``
+  Include directories needed to use RakNet.
+``RakNet_LIBRARIES``
+  Libraries needed to link to RakNet.
+
+Cache Variables
+^^^^^^^^^^^^^^^
+
+The following cache variables may also be set:
+
+``RakNet_INCLUDE_DIR``
+  The directory containing ``RakPeer.h``.
+``RakNet_LIBRARY_DEBUG``
+  The path to the RakNet library (Debug configuration).
+``RakNet_LIBRARY_RELEASE``
+  The path to the RakNet library (Release configuration).
+
+#]=======================================================================]
+
+find_path(RakNet_INCLUDE_DIR
+  NAMES RakPeer.h
+  PATHS /usr /usr/local /opt/local ${RakNet_INCLUDES}
+        ENV CPATH ENV RAKNET_ROOT
+  PATH_SUFFIXES include include/raknet RakNet raknet
+)
+find_library(RakNet_LIBRARY_RELEASE
+  NAMES RakNetLibStatic
+  PATHS /usr /usr/local /opt/local
+        ENV LD_LIBRARY_PATH ENV LIBRARY_PATH ENV RAKNET_ROOT
+  PATH_SUFFIXES lib lib64
+)
+find_library(RakNet_LIBRARY_DEBUG
+  NAMES RakNetLibStaticd
+  PATHS /usr /usr/local /opt/local
+        ENV LD_LIBRARY_PATH ENV LIBRARY_PATH ENV RAKNET_ROOT
+  PATH_SUFFIXES lib lib64
+)
+
+include(SelectLibraryConfigurations)
+select_library_configurations(RakNet)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(RakNet
+  FOUND_VAR RakNet_FOUND
+  REQUIRED_VARS
+    RakNet_LIBRARY
+    RakNet_INCLUDE_DIR
+)
+
+if(RakNet_FOUND)
+  if(WIN32)
+    set(RakNet_LIBRARY "${RakNet_LIBRARY}" ws2_32.lib)
+  endif()
+  set(RakNet_LIBRARIES ${RakNet_LIBRARY})
+  set(RakNet_INCLUDE_DIRS ${RakNet_INCLUDE_DIR})
+  if (NOT TARGET RakNet::RakNet)
+    add_library(RakNet::RakNet UNKNOWN IMPORTED)
+  endif()
+  if (RakNet_LIBRARY_RELEASE)
+    set_property(TARGET RakNet::RakNet APPEND PROPERTY
+      IMPORTED_CONFIGURATIONS RELEASE
     )
-	
-FIND_LIBRARY (RakNet_LIBRARY_DEBUG NAMES RakNetLibStaticd
-    PATHS
-    ENV LD_LIBRARY_PATH
-    ENV LIBRARY_PATH
-    /usr/lib64
-    /usr/lib
-    /usr/local/lib64
-    /usr/local/lib
-    /opt/local/lib
-    $ENV{RAKNET_ROOT}/lib
-    )	
-	
-	
-
-FIND_PATH (RakNet_INCLUDES raknet/RakPeer.h
-    ENV CPATH
-    /usr/include
-    /usr/local/include
-    /opt/local/include
-	$ENV{RAKNET_ROOT}/include
+    set_target_properties(RakNet::RakNet PROPERTIES
+      IMPORTED_LOCATION_RELEASE "${RakNet_LIBRARY_RELEASE}"
     )
- 
-MESSAGE(STATUS ${RakNet_INCLUDES})
-MESSAGE(STATUS ${RakNet_LIBRARY_RELEASE})
- 
-IF(RakNet_INCLUDES AND RakNet_LIBRARY_RELEASE)
-    SET(RakNet_FOUND TRUE)
-ENDIF(RakNet_INCLUDES AND RakNet_LIBRARY_RELEASE)
+  endif()
+  if (RakNet_LIBRARY_DEBUG)
+    set_property(TARGET RakNet::RakNet APPEND PROPERTY
+      IMPORTED_CONFIGURATIONS DEBUG
+    )
+    set_target_properties(RakNet::RakNet PROPERTIES
+      IMPORTED_LOCATION_DEBUG "${RakNet_LIBRARY_DEBUG}"
+    )
+  endif()
+  set_target_properties(RakNet::RakNet PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${RakNet_INCLUDE_DIR}"
+  )
+  message(STATUS "Found RakNet_INCLUDE_DIRS: ${RakNet_INCLUDE_DIRS}")
+endif()
 
-IF(RakNet_FOUND)
-  SET(RakNet_INCLUDES ${RakNet_INCLUDES}/raknet)
-  
-  
-   IF (CMAKE_CONFIGURATION_TYPES OR CMAKE_BUILD_TYPE)
-        SET(RakNet_LIBRARY optimized ${RakNet_LIBRARY_RELEASE} debug ${RakNet_LIBRARY_DEBUG})
-		IF(WIN32)
-			SET(RakNet_LIBRARY optimized ${RakNet_LIBRARY_RELEASE} debug ${RakNet_LIBRARY_DEBUG} ws2_32.lib)
-		ENDIF(WIN32)
-   ELSE()
-        # if there are no configuration types and CMAKE_BUILD_TYPE has no value
-        # then just use the release libraries
-        SET(RakNet_LIBRARY ${RakNet_LIBRARY_RELEASE} )
-		IF(WIN32)
-			SET(RakNet_LIBRARY ${RakNet_LIBRARY_RELEASE} ws2_32.lib)
-		ENDIF(WIN32)
-   ENDIF()
-   
-  IF(NOT RakNet_FIND_QUIETLY)
-    MESSAGE(STATUS "Found RakNet_LIBRARY_RELEASE: ${RakNet_LIBRARY_RELEASE}")
-    MESSAGE(STATUS "Found RakNet_INCLUDES: ${RakNet_INCLUDES}")
-  ENDIF(NOT RakNet_FIND_QUIETLY)
-ELSE(RakNet_FOUND)
-  IF(RakNet_FIND_REQUIRED)
-    MESSAGE(FATAL_ERROR "Could not find RakNet")
-  ENDIF(RakNet_FIND_REQUIRED)
-ENDIF(RakNet_FOUND)
-
+mark_as_advanced(
+  RakNet_INCLUDE_DIR
+  RakNet_LIBRARY_DEBUG
+  RakNet_LIBRARY_RELEASE
+)


### PR DESCRIPTION
This commit fixes (at least) the following problems:

1. cmake will "find" RakNet include directory even if the cmake option `-DRakNet_INCLUDES` CACHE entry value is incorrect. The build will fail later when an included RakNet file is missing. (To test, change to `-DRakNet_INCLUDES="/tmp/CrabNet/includex"` below.)

2. cmake will not find the RakNet Release library (which exists at the path specified with `-DRakNet_LIBRARY_RELEASE`) unless `-DRakNet_LIBRARY_DEBUG` is defined (to any value). (To test, remove the `-DRakNet_LIBRARY_DEBUG` line below.)

3. cmake will not find anything if only the environment variable `RAKNET_ROOT` is set, although it appears that it was intended to be used as a search path. (To test, add `RAKNET_ROOT=/tmp/CrabNet` and remove the three `-DRakNet_` lines.)

This commit was tested with the following cmake command in a Debian bookworm container with CrabNet and osg directories in `/tmp`:

```sh
mkdir build/
cd build/
cmake .. -DBUILD_BROWSER=OFF \
         -DBUILD_BSATOOL=OFF \
         -DBUILD_ESMTOOL=OFF \
         -DBUILD_ESSIMPORTER=OFF \
         -DBUILD_LAUNCHER=OFF \
         -DBUILD_MWINIIMPORTER=OFF \
         -DBUILD_NIFTEST=OFF \
         -DBUILD_OPENCS=OFF \
         -DBUILD_OPENMW=ON \
         -DBUILD_OPENMW_MP=OFF \
         -DBUILD_WIZARD=OFF \
         -DCMAKE_BUILD_TYPE=Release \
         -DOPENSCENEGRAPH_INCLUDE_DIRS=/tmp/osg/include \
         -DRakNet_INCLUDES="/tmp/CrabNet/include" \
         -DRakNet_LIBRARY_DEBUG="/tmp/CrabNet/lib/libRakNetLibStaticd.a" \
         -DRakNet_LIBRARY_RELEASE="/tmp/CrabNet/lib/libRakNetLibStatic.a"
make -j $(nproc)
```