### PR TITLE
Add missing dependencies for MSVC builds

### DIFF
--- a/CI/before_script.msvc.sh
+++ b/CI/before_script.msvc.sh
@@ -584,6 +584,17 @@ if [ -z $SKIP_DOWNLOAD ]; then
 			git clone -b release-1.10.0 https://github.com/google/googletest.git
 		fi
 	fi
+
+	# RakNet/CrabNet
+	echo "RakNet/CrabNet 19e66190e8 ..."
+	if [[ -d CrabNet ]]; then
+		echo "  directory exists, skipping."
+	else
+		git clone https://github.com/TES3MP/CrabNet.git
+		cd CrabNet
+		git reset --hard 19e66190e83f53bcdcbcd6513238ed2e54878a21
+		cd ..
+	fi
 fi
 
 cd .. #/..
@@ -987,6 +998,29 @@ if [ ! -z $TEST_FRAMEWORK ]; then
 	echo Done.
 
 fi
+cd $DEPS
+echo
+# RakNet/CrabNet
+printf "RakNet/CrabNet... "
+{
+	if [[ -d $DEPS_INSTALL/CrabNet ]]; then
+		echo "already built"
+	else
+		cd CrabNet/
+		rm -rf build
+		mkdir build
+		cd build/
+		cmake -DCMAKE_BUILD_TYPE=Release ..
+		cmake --build . --target RakNetLibStatic --config Release \
+			--clean-first -- -maxcpucount
+		cd ../..
+		cp -r CrabNet/ $DEPS_INSTALL
+		echo Done.
+	fi
+	add_cmake_opts -DRakNet_INCLUDES=$DEPS_INSTALL/CrabNet/include
+	add_cmake_opts -DRakNet_LIBRARY_RELEASE=$DEPS_INSTALL/CrabNet/build/lib/Release/RakNetLibStatic.lib
+	add_cmake_opts -DRakNet_LIBRARY_DEBUG=$DEPS_INSTALL/CrabNet/build/lib/Release/RakNetLibStatic.lib
+}
 
 echo
 cd $DEPS_INSTALL/..

--- a/CI/before_script.msvc.sh
+++ b/CI/before_script.msvc.sh
@@ -595,6 +595,17 @@ if [ -z $SKIP_DOWNLOAD ]; then
 		git reset --hard 19e66190e83f53bcdcbcd6513238ed2e54878a21
 		cd ..
 	fi
+
+	# LuaJIT
+	echo "LuaJit c525bcb902 ..."
+	if [[ -d LuaJIT ]]; then
+		printf "  directory exists, skipping."
+	else
+		git clone https://luajit.org/git/luajit.git
+		cd luajit
+		git reset --hard c525bcb9024510cad9e170e12b6209aedb330f83
+		cd ..
+	fi
 fi
 
 cd .. #/..
@@ -1020,6 +1031,28 @@ printf "RakNet/CrabNet... "
 	add_cmake_opts -DRakNet_INCLUDES=$DEPS_INSTALL/CrabNet/include
 	add_cmake_opts -DRakNet_LIBRARY_RELEASE=$DEPS_INSTALL/CrabNet/build/lib/Release/RakNetLibStatic.lib
 	add_cmake_opts -DRakNet_LIBRARY_DEBUG=$DEPS_INSTALL/CrabNet/build/lib/Release/RakNetLibStatic.lib
+}
+cd $DEPS
+echo
+# LuaJIT
+printf "LuaJIT... "
+{
+	if [[ -d $DEPS_INSTALL/luajit ]]; then
+		echo "already built"
+	else
+		cd $DEPS/luajit/
+		mingw32-make -j $NUMBER_OF_PROCESSORS
+		tmp=$DEPS_INSTALL/tmp/luajit
+		mkdir -p $tmp/lua
+		cp src/luajit.exe $tmp
+		cp -r src/jit src/lua51.dll $tmp/lua/
+		mv $tmp $DEPS_INSTALL
+	fi
+	add_cmake_opts -DLuaJit_INCLUDE_DIR=$DEPS_INSTALL/luajit/lua
+	add_cmake_opts -DLuaJit_LIBRARY=$DEPS_INSTALL/luajit/lua
+	for config in ${CONFIGURATIONS[@]}; do
+		add_runtime_dlls $config $DEPS_INSTALL/luajit/lua/lua51.dll
+	done
 }
 
 echo


### PR DESCRIPTION
These two commits add LuaJit and CrabNet dependencies to `CI/before_script.msvc.sh`.