### PR TITLE
Fix Qt dependency: install setuptools to venv

### DIFF
--- a/CI/before_script.msvc.sh
+++ b/CI/before_script.msvc.sh
@@ -862,6 +862,8 @@ fi
 			# check version
 			aqt-venv/${VENV_BIN_DIR}/pip list | grep 'aqtinstall\s*1.1.3' || [ $? -ne 0 ]
 			if [ $? -eq 0 ]; then
+                                echo "  Installing setuptools into virtualenv..."
+                                run_cmd "aqt-venv/${VENV_BIN_DIR}/pip" install setuptools
 				echo "  Installing aqt wheel into virtualenv..."
 				run_cmd "aqt-venv/${VENV_BIN_DIR}/pip" install aqtinstall==1.1.3
 			fi


### PR DESCRIPTION
In `CI/before_script.msvc.sh`, while executing the following line:

run_cmd "aqt-venv/${VENV_BIN_DIR}/pip" install aqtinstall==1.1.3

This error is raised:

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\TES3MP.git\deps\aqt-venv\Scripts\aqt.exe\__main__.py", line 4, in <module>
  File "C:\TES3MP.git\deps\aqt-venv\Lib\site-packages\aqt\__init__.py", line 23, in <module>
    from pkg_resources import DistributionNotFound, get_distribution
ModuleNotFoundError: No module named 'pkg_resources'
```

This commit fixes that by first installing setuptools.