### PR TITLE
Call cmake_minimum_required() before project()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
-project(OpenMW)
 cmake_minimum_required(VERSION 3.1.0)
+
+project(OpenMW)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 


### PR DESCRIPTION
This fixes the following warning:

```
CMake Warning (dev) at CMakeLists.txt:1 (project):
cmake_minimum_required() should be called prior to this top-level project()
call.  Please see the cmake-commands(7) manual for usage documentation of
both commands.
```

This is a small part of upstream OpenMW commit a40ec4edd6459e54003d6df3f1b05f2c4241f028.